### PR TITLE
Replace the deprecated devel block with head

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ brew install hhu-stups/prob/prob
 To install the current **nightly build** run:
 
 ```
-brew install hhu-stups/prob/prob --devel
+brew install hhu-stups/prob/prob --head
 ```
 
 ## Updating Formula

--- a/prob.rb
+++ b/prob.rb
@@ -8,7 +8,7 @@ class Prob < BaseProB
 
   bottle :unneeded
 
-  devel do
+  head do
     # We use the current date to identify each nightly build
     version Time.now.strftime("%Y%m%d") + "-nightly"
 


### PR DESCRIPTION
brew now produces the following warning each time it is used with the `prob` formula installed:

```
Warning: Calling 'devel' blocks in formulae is deprecated! Use 'head' blocks or @-versioned formulae instead.
Please report this issue to the hhu-stups/prob tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/hhu-stups/homebrew-prob/prob.rb:11

```
[devel blocks are deprecated](https://github.com/Homebrew/brew/commit/22857b56b9ff732c83f9bde3b58c3d579ac7f3b1) since version 2.4.0 of Homebrew. This pull request simply replaces the `devel` block with the `head` block.

Another possible solution is to create a separate prob-nightly formula.