### PR TITLE
Remove "bottle :unneeded" as it is deprecated

### DIFF
--- a/lib/base-prob.rb
+++ b/lib/base-prob.rb
@@ -2,8 +2,6 @@ class BaseProB < Formula
   desc "The ProB Animator and Model Checker"
   homepage "https://www3.hhu.de/stups/prob/index.php/Main_Page"
 
-  bottle :unneeded
-
   depends_on :arch => :x86_64
   depends_on :macos => :yosemite
 

--- a/prob.rb
+++ b/prob.rb
@@ -6,8 +6,6 @@ class Prob < BaseProB
   version "1.10.2"
   sha256 "4041e78abcc392b2583f2d674520ac14ecf8513aadd4a696c71eb3b8b9887508"
 
-  bottle :unneeded
-
   head do
     # We use the current date to identify each nightly build
     version Time.now.strftime("%Y%m%d") + "-nightly"


### PR DESCRIPTION
`bottle :unneeded` is deprecated and should be removed. Corresponding issue: https://github.com/Homebrew/homebrew-core/issues/75943
```
$ brew upgrade
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the hhu-stups/prob tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/hhu-stups/homebrew-prob/lib/base-prob.rb:5

Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the hhu-stups/prob tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/hhu-stups/homebrew-prob/prob.rb:9
```